### PR TITLE
Feature/more robust reverse

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -2,7 +2,7 @@ const db = require('./db')
 const transactions = require('./transactions')
 
 function activate(transactionGuid, identifier, initialBalance) {
-  var card = getCard(identifier)
+  var card = find(identifier)
   if(card['active']) throw "ERROR_CARD_ALREADY_ACTIVATED";
   card['active'] = true;
   if(initialBalance!=null){
@@ -13,7 +13,7 @@ function activate(transactionGuid, identifier, initialBalance) {
 }
 
 function addValue(transactionGuid, identifier, amount) {
-  var card = getCard(identifier);
+  var card = find(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   var origBalance = parseFloat(card['balance']);
   card['balance'] = (origBalance + parseFloat(amount)).toFixed(2); // toFixed(2) will turn the double into a string with 2 places after the decimal
@@ -22,13 +22,13 @@ function addValue(transactionGuid, identifier, amount) {
 }
 
 function getBalance(identifier) {
-  var card = getCard(identifier);
+  var card = find(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   return card['balance'];
 }
 
 function redeem(transactionGuid, identifier, amount) {
-  var card = getCard(identifier);
+  var card = find(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   var origBalance = parseFloat(card['balance']);
   var balance = origBalance - parseFloat(amount);
@@ -39,11 +39,10 @@ function redeem(transactionGuid, identifier, amount) {
 }
 
 function reverse(newTransactionGuid, oldTransactionGuid, identifier) {
-  var card = getCard(identifier);
+  var card = find(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   var transaction = transactions.find(oldTransactionGuid, identifier);
   if (transaction['reversed']) throw "ERROR_TRANSACTION_ALREADY_REVERSED"
-  var card = getCard(identifier);
   var currentBalance = parseFloat(card['balance']);
   var transactionAmount = parseFloat(transaction['amount']);
   switch(transaction['method']){
@@ -79,4 +78,4 @@ function update(card) {
   return card;
 }
 
-module.exports = {activate, deactivate, addValue, getBalance, redeem, find};
+module.exports = {activate, addValue, getBalance, redeem, reverse, find};

--- a/cards.js
+++ b/cards.js
@@ -47,6 +47,8 @@ function reverse(newTransactionGuid, oldTransactionGuid, identifier) {
   var transactionAmount = parseFloat(transaction['amount']);
   switch(transaction['method']){
     case "activate":
+      // If the current balance is different than the original balance, that means there have
+      // already been transactions on the card, which means it's too late to reverse the activate
       if (currentBalance != transactionAmount) throw "ERROR_TRANSACTION_CANNOT_BE_REVERSED"
       card['active'] = false;
       card['balance'] = '0.00';

--- a/cards.js
+++ b/cards.js
@@ -1,20 +1,23 @@
 const db = require('./db')
+const transactions = require('./transactions')
 
-function activate(identifier, initialBalance) {
-  if(getCard(identifier)['active']) throw "ERROR_CARD_ALREADY_ACTIVATED";
-  return setActivate(identifier, initialBalance, true);
+function activate(transactionGuid, identifier, initialBalance) {
+  var card = getCard(identifier)
+  if(card['active']) throw "ERROR_CARD_ALREADY_ACTIVATED";
+  card['active'] = true;
+  if(initialBalance!=null){
+    card['balance'] = parseFloat(initialBalance).toFixed(2);
+  }
+  transactions.create('activate', transactionGuid, identifier, initialBalance);
+  return update(card);
 }
 
-function deactivate(identifier) {
-  if(!getCard(identifier)['active']) throw "ERROR_CARD_NOT_ACTIVATED";
-  return setActivate(identifier, "0.0", false);
-}
-
-function addValue(identifier, amount) {
+function addValue(transactionGuid, identifier, amount) {
   var card = getCard(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   var origBalance = parseFloat(card['balance']);
   card['balance'] = (origBalance + parseFloat(amount)).toFixed(2); // toFixed(2) will turn the double into a string with 2 places after the decimal
+  transactions.create('add_value', transactionGuid, identifier, amount);
   return update(card);
 }
 
@@ -24,38 +27,55 @@ function getBalance(identifier) {
   return card['balance'];
 }
 
-function redeem(identifier, amount) {
+function redeem(transactionGuid, identifier, amount) {
   var card = getCard(identifier);
   if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
   var origBalance = parseFloat(card['balance']);
   var balance = origBalance - parseFloat(amount);
   if (balance < 0.0) balance = 0.0;
   card['balance'] = balance.toFixed(2);
+  transactions.create('redeem', transactionGuid, identifier, amount);
+  return update(card);
+}
+
+function reverse(newTransactionGuid, oldTransactionGuid, identifier) {
+  var card = getCard(identifier);
+  if(!card['active']) throw "ERROR_CARD_NOT_ACTIVATED";
+  var transaction = transactions.find(oldTransactionGuid, identifier);
+  if (transaction['reversed']) throw "ERROR_TRANSACTION_ALREADY_REVERSED"
+  var card = getCard(identifier);
+  var currentBalance = parseFloat(card['balance']);
+  var transactionAmount = parseFloat(transaction['amount']);
+  switch(transaction['method']){
+    case "activate":
+      if (currentBalance != transactionAmount) throw "ERROR_TRANSACTION_CANNOT_BE_REVERSED"
+      card['active'] = false;
+      card['balance'] = '0.00';
+      break;
+    case "redeem":
+      card['balance'] = (currentBalance - transactionAmount).toFixed(2);
+      break;
+    case "add_value":
+      if (currentBalance < transactionAmount) throw "ERROR_TRANSACTION_CANNOT_BE_REVERSED"
+      card['balance'] = (currentBalance - transactionAmount).toFixed(2);        
+      break;
+    default:
+      throw "ERROR_TRANSACTION_CANNOT_BE_REVERSED"
+  }
+  transaction['reversed'] = true;
+  transactions.update(transaction);
+  transactions.create('reverse', newTransactionGuid, identifier, -1 * transactionAmount);
   return update(card);
 }
 
 function find(identifier) {
-  return getCard(identifier);
-}
-
-
-function setActivate(identifier, initialBalance, activate) {
-  var card = getCard(identifier)
-  card['active'] = activate;
-  if(initialBalance!=null){
-    card['balance'] = parseFloat(initialBalance).toFixed(2);
-  }
-  return update(card);
+  var card = db.find('cards', {number: identifier});
+  if (card == null) throw "ERROR_CARD_INVALID";
+  return card;
 }
 
 function update(card) {
   db.update('cards', card);
-  return card;
-}
-
-function getCard(identifier) {
-  var card = db.find('cards', {number: identifier});
-  if (card == null) throw "ERROR_CARD_INVALID";
   return card;
 }
 

--- a/db.json
+++ b/db.json
@@ -21,25 +21,29 @@
       "guid": "449191cb-1479-4046-a1e1-4ff761bffae5",
       "method": "activate",
       "amount": 2.22,
-      "cardNumber": "2"
+      "cardNumber": "2",
+      "reversed": false
     },
     {
       "guid": "40d052e0-9df4-4ed1-906e-9072a46f6cfa",
       "method": "add_value",
       "amount": 0.02,
-      "cardNumber": "2"
+      "cardNumber": "2",
+      "reversed": false
     },
     {
       "guid": "13ae2bf3-86a8-478a-aa7a-26a523cef4fe",
       "method": "redeem",
       "amount": 2.24,
-      "cardNumber": "2"
+      "cardNumber": "2",
+      "reversed": false
     },
     {
       "guid": "f54140bb-80e7-4a36-813b-6c05ad847286",
       "method": "redeem",
       "amount": 11.68,
-      "cardNumber": "1"
+      "cardNumber": "1",
+      "reversed": false
     }
   ]
 }

--- a/transactions.js
+++ b/transactions.js
@@ -13,7 +13,7 @@ function create(type, transactionGuid, identifier, amount){
 
 function update(transaction){
   if (transaction['guid'] == null) throw "ERROR_INVALID_INPUT_PROPERTIES";
-  db.udpate('transactions', transaction);
+  db.update('transactions', transaction);
 }
 
 function find(transactionGuid, cardNumber){

--- a/transactions.js
+++ b/transactions.js
@@ -1,32 +1,22 @@
 const db = require('./db')
-const cards = require('./cards')
 
-function save(transaction){
+function create(type, transactionGuid, identifier, amount){
+  if (transactionGuid == null) throw "ERROR_INVALID_INPUT_PROPERTIES";
+  db.push('transactions', {
+    guid: transactionGuid,
+    method: type,
+    amount: amount,
+    cardNumber: identifier,
+    reversed: false
+  });
+}
+
+function update(transaction){
   if (transaction['guid'] == null) throw "ERROR_INVALID_INPUT_PROPERTIES";
-  db.push('transactions', transaction);
+  db.udpate('transactions', transaction);
 }
 
-function reverse(transactionGuid, cardNumber){
-  var transaction = getTransaction(transactionGuid, cardNumber);
-  var method = transaction['method'];
-  var amount = transaction['amount'];
-  var cardNumber = transaction['cardNumber'];
-  var card;
-  switch(method){
-    case "activate":
-      card = cards.deactivate(cardNumber);
-      break;
-    case "redeem":
-      card = cards.addValue(cardNumber, amount);
-      break;
-    case "add_value":
-      card = cards.redeem(cardNumber, amount);
-      break;
-  }
-  return card['balance'];
-}
-
-function getTransaction(transactionGuid, cardNumber){
+function find(transactionGuid, cardNumber){
   var txn = db.find('transactions', {
     guid: transactionGuid,
     cardNumber: cardNumber
@@ -35,4 +25,4 @@ function getTransaction(transactionGuid, cardNumber){
   return txn;
 }
 
-module.exports = {save, reverse}
+module.exports = {create, update, find}


### PR DESCRIPTION
Making some structural changes to streamline the workflow, and having reverse work closer to how a production system should work.

- Changed the calling structure to be more straightforward, so `server` now calls the operation on `cards`, which creates necessary `transactions`, instead of the logic being split between the three files.
- Added a `reversed` field to the transactions table. A reverse now marks the transaction as reversed, and creates an explicit `reverse` transaction, rather than creating a transaction of the opposite type.
-- As a corollary, there is no longer an explicit deactivate call.